### PR TITLE
商品一覧機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,10 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only:[:new]
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def index
+    @items = Item.all
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -155,8 +155,7 @@
           </li>
         <% end %>
       <% else %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      
        <li class='list'>
          <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -175,8 +174,7 @@
          <% end %>
        </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      
      
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,57 +127,55 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                 <%# <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                 </div> %>
+               <%# //商品が売れていればsold outを表示しましょう %>
+              </div> 
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                      <%= item.name %>
+                  </h3>
+                     <div class='item-price'>
+                      <span><%= item.price %>円<br><%= item.fee.name %></span>
+                      <div class='star-btn'>
+                        <%= image_tag "star.png", class:"star-icon" %>
+                        <span class='star-count'>0</span>
+                      </div>
+                     </div>
+                </div>      
+           <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+         <div class='item-info'>
+           <h3 class='item-name'>
+             商品を出品してね！
+           </h3>
+           <div class='item-price'>
+             <span>99999999円<br>(税込み)</span>
+             <div class='star-btn'>
+               <%= image_tag "star.png", class:"star-icon" %>
+               <span class='star-count'>0</span>
+             </div>
+           </div>
+         </div>
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+     
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,6 +127,7 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
+      <% if @items.exists? %>
         <% @items.each do |item| %>
           <li class='list'>
             <%= link_to "#" do %>
@@ -153,26 +154,27 @@
            <% end %>
           </li>
         <% end %>
-
+      <% else %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-         <div class='item-info'>
-           <h3 class='item-name'>
-             商品を出品してね！
-           </h3>
-           <div class='item-price'>
-             <span>99999999円<br>(税込み)</span>
-             <div class='star-btn'>
-               <%= image_tag "star.png", class:"star-icon" %>
-               <span class='star-count'>0</span>
-             </div>
-           </div>
-         </div>
-        <% end %>
-      </li>
+       <li class='list'>
+         <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+         <% end %>
+       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
      

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
 
-  resources :items, only: [:new, :create, :edit, :update]
+  resources :items, only: [:index, :new, :create, :edit, :update]
 end


### PR DESCRIPTION
＃What
商品の一覧を表示するようにした。
所品購入機能実装後にsoldout表示は実装する予定なので今回は未実装

＃Why
売りに出された商品を見られるようにするため


商品のデータがない場合は、ダミー商品が表示されている
https://gyazo.com/0fcb60b03642c739248c9e5168c68b83

商品のデータがある場合は、商品が一覧で表示されている
https://gyazo.com/8b9a4cfd74d8dbbc803d4f051355662e